### PR TITLE
launch_jobs_from_branch_manually

### DIFF
--- a/.github/workflows/run-jobs.yml
+++ b/.github/workflows/run-jobs.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.branch_name }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -53,6 +54,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.branch_name }}
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Добавлена возможность запуска jobs вручную. В первом выпадающем списке выбирается ветка, с которой возьмется yml файл для запуска jobs. Во втором поле вводится название ветки, на которой надо запустить jobs

Closes #43 